### PR TITLE
[SERVICE-989] Add support for runtime-injected services

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.4",
   "description": "",
   "main": "Store.js",
+  "types": "Store.d.ts",
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && node src/fileCopy.js",
     "check": "svc-tools check",
@@ -24,10 +25,6 @@
     "openfin-service-tooling": "^1.0.31",
     "rimraf": "^2.6.3",
     "typescript": "^3.8.3"
-  },
-  "peerDependencies": {
-    "openfin-service-signal": "^1.0.0",
-    "openfin-service-tooling": "^1.0.12"
   },
   "dependencies": {
     "json-schema-defaults": "^0.4.0",

--- a/test/loader.unittest.ts
+++ b/test/loader.unittest.ts
@@ -69,6 +69,7 @@ function createAppWithConfig(uuid: string, config: Partial<ConfigWithRules<Confi
     if (serviceType === 'desktop-service') {
         manifest = {services: [{name: 'testService', config}]};
     } else {
+        // eslint-disable-next-line @typescript-eslint/camelcase
         manifest = {startup_app: {testServiceApi: true, testServiceConfig: config}};
     }
 
@@ -164,7 +165,7 @@ it.each<[ServiceType, ServiceType]>([
     ['desktop-service', 'desktop-service'],
     ['desktop-service', 'runtime-injected'],
     ['runtime-injected', 'runtime-injected'],
-    ['runtime-injected', 'desktop-service'],
+    ['runtime-injected', 'desktop-service']
 ])('For independent applications of type "%s" and "%s", there is no shared lifecycle', async (type1, type2) => {
     const app1: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false}, type1);
     const app2: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false}, type2);

--- a/test/loader.unittest.ts
+++ b/test/loader.unittest.ts
@@ -7,7 +7,7 @@ import {Store, ConfigWithRules} from '../src/Store';
 import {RequiredRecursive} from '../src/ConfigUtil';
 
 import {delay, Duration} from './utils/delay';
-import {fin} from './utils/fin';
+import {fin, resetFin} from './utils/fin';
 import {FakeApplication} from './utils/FakeApplication';
 import {FakeWindow} from './utils/FakeWindow';
 
@@ -35,6 +35,7 @@ interface ConfigTemplate {
 }
 
 type Config = RequiredRecursive<ConfigTemplate>;
+type ServiceType = 'desktop-service' | 'runtime-injected';
 
 const defaults: Config = {
     enabled: true,
@@ -57,95 +58,116 @@ function getWindowConfig(storeConfig: Store<ConfigTemplate>, identity: Identity)
     return storeConfig.query({level: 'window', uuid: identity.uuid, name: identity.name || identity.uuid});
 }
 
-function createAppWithConfig(uuid: string, config: Partial<ConfigWithRules<ConfigTemplate>>, parentUuid?: string): Promise<FakeApplication> {
-    if (parentUuid) {
-        const parentApp: FakeApplication = fin.Application.wrapSync({uuid: parentUuid});
-        return parentApp.createChildApp({uuid});
+function createChildApp(uuid: string, parentUuid: string): Promise<FakeApplication> {
+    const parentApp: FakeApplication = fin.Application.wrapSync({uuid: parentUuid});
+    return parentApp.createChildApp({uuid});
+}
+
+function createAppWithConfig(uuid: string, config: Partial<ConfigWithRules<ConfigTemplate>>, serviceType: ServiceType): Promise<FakeApplication> {
+    let manifest;
+
+    if (serviceType === 'desktop-service') {
+        manifest = {services: [{name: 'testService', config}]};
     } else {
-        return fin.Application.create({uuid}, {services: [{name: 'testService', config}]});
+        manifest = {startup_app: {testServiceApi: true, testServiceConfig: config}};
     }
+
+    return fin.Application.create({uuid}, manifest);
 }
 
 beforeEach(() => {
+    // Suppress console output within tests
+    jest.spyOn(console, 'log').mockImplementation();
+
+    // Clear existing listeners/apps
+    resetFin();
+
     store = new Store<ConfigTemplate>(defaults);
     loader = new Loader<ConfigTemplate>(store, 'testService');
 });
 
-it('Config is loaded from an application\'s manifest', async () => {
-    const app: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false});
+describe.each<ServiceType>(['desktop-service', 'runtime-injected'])('When application uses the service via "%s" method', (type) => {
+    it('Config is loaded from an application\'s manifest', async () => {
+        const app: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false}, type);
 
-    await delay(Duration.STORE_LOADING);
+        await delay(Duration.STORE_LOADING);
 
-    // Config specifies that window shouldn't be registered
-    const config: Config = getWindowConfig(store, app.identity);
+        // Config specifies that window shouldn't be registered
+        const config: Config = getWindowConfig(store, app.identity);
 
-    assert.strictEqual(config.enabled, false);
-});
-
-it('Config is loaded from desktop owner file', async () => {
-    expect(store.query({level: 'desktop'}).features).toEqual({featureOne: true, featureTwo: false, featureThree: true});
-});
-
-it('Config is unloaded when the application exits', async () => {
-    const app: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false});
-
-    await delay(Duration.STORE_LOADING);
-
-    // Sanity check - make sure config was definitely loaded initially
-    const preConfig: Config = getWindowConfig(store, app.identity);
-    assert.strictEqual(preConfig.enabled, false);
-
-    await app.close();
-
-    // App-specific config has been removed, querying 'enabled' returns the default value of true
-    const postConfig: Config = getWindowConfig(store, app.identity);
-    assert.strictEqual(postConfig.enabled, true);
-});
-
-it('If an application creates a child application, the config of the parent application persists for the lifecycle of its child', async () => {
-    const app: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false});
-    const child: FakeApplication = await createAppWithConfig(createUuid(), {}, app.identity.uuid);
-
-    await delay(Duration.STORE_LOADING);
-
-    // Config should disable main app, child app remains registered
-    assert.strictEqual((getWindowConfig(store, app.identity)).enabled, false);
-    assert.strictEqual((getWindowConfig(store, child.identity)).enabled, true);
-
-    await app.close();
-
-    // No change in config state, as child app extends the lifespan of main app's config
-    assert.strictEqual((getWindowConfig(store, app.identity)).enabled, false);
-    assert.strictEqual((getWindowConfig(store, child.identity)).enabled, true);
-
-    await child.close();
-
-    // Config should now revert to initial state (everything enabled)
-    assert.strictEqual((getWindowConfig(store, app.identity)).enabled, true);
-    assert.strictEqual((getWindowConfig(store, child.identity)).enabled, true);
-});
-
-it('If an application creates a child application, the parent can apply rules to the child that still apply after the parent exits', async () => {
-    const childAppUuid: string = createUuid();
-    const app: FakeApplication = await createAppWithConfig(createUuid(), {
-        enabled: false,
-        rules: [{scope: {level: 'application', uuid: childAppUuid}, config: {features: {featureOne: false}}}]
+        assert.strictEqual(config.enabled, false);
     });
-    const childApp: FakeApplication = await createAppWithConfig(childAppUuid, {}, app.identity.uuid);
-    const childWindow: FakeWindow = childApp.createChildWindow('child-window-1');
 
-    await delay(Duration.STORE_LOADING);
+    it('Config is loaded from desktop owner file', async () => {
+        expect(store.query({level: 'desktop'}).features).toEqual({featureOne: true, featureTwo: false, featureThree: true});
+    });
 
-    await app.close();
-    await delay(Duration.STORE_LOADING);
+    it('Config is unloaded when the application exits', async () => {
+        const app: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false}, type);
 
-    assert.strictEqual(getWindowConfig(store, childApp.identity).features.featureOne, false);
-    assert.strictEqual(getWindowConfig(store, childWindow.identity).features.featureOne, false);
+        await delay(Duration.STORE_LOADING);
+
+        // Sanity check - make sure config was definitely loaded initially
+        const preConfig: Config = getWindowConfig(store, app.identity);
+        assert.strictEqual(preConfig.enabled, false);
+
+        await app.close();
+
+        // App-specific config has been removed, querying 'enabled' returns the default value of true
+        const postConfig: Config = getWindowConfig(store, app.identity);
+        assert.strictEqual(postConfig.enabled, true);
+    });
+
+    it('If an application creates a child application, the config of the parent application persists for the lifecycle of its child', async () => {
+        const app: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false}, type);
+        const child: FakeApplication = await createChildApp(createUuid(), app.identity.uuid);
+
+        await delay(Duration.STORE_LOADING);
+
+        // Config should disable main app, child app remains registered
+        assert.strictEqual((getWindowConfig(store, app.identity)).enabled, false);
+        assert.strictEqual((getWindowConfig(store, child.identity)).enabled, true);
+
+        await app.close();
+
+        // No change in config state, as child app extends the lifespan of main app's config
+        assert.strictEqual((getWindowConfig(store, app.identity)).enabled, false);
+        assert.strictEqual((getWindowConfig(store, child.identity)).enabled, true);
+
+        await child.close();
+
+        // Config should now revert to initial state (everything enabled)
+        assert.strictEqual((getWindowConfig(store, app.identity)).enabled, true);
+        assert.strictEqual((getWindowConfig(store, child.identity)).enabled, true);
+    });
+
+    it('If an application creates a child application, the parent can apply rules to the child that still apply after the parent exits', async () => {
+        const childAppUuid: string = createUuid();
+        const app: FakeApplication = await createAppWithConfig(createUuid(), {
+            enabled: false,
+            rules: [{scope: {level: 'application', uuid: childAppUuid}, config: {features: {featureOne: false}}}]
+        }, type);
+        const childApp: FakeApplication = await createChildApp(childAppUuid, app.identity.uuid);
+        const childWindow: FakeWindow = childApp.createChildWindow('child-window-1');
+
+        await delay(Duration.STORE_LOADING);
+
+        await app.close();
+        await delay(Duration.STORE_LOADING);
+
+        assert.strictEqual(getWindowConfig(store, childApp.identity).features.featureOne, false);
+        assert.strictEqual(getWindowConfig(store, childWindow.identity).features.featureOne, false);
+    });
 });
 
-it('For two independent applications, there is no shared lifecycle', async () => {
-    const app1: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false});
-    const app2: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false});
+it.each<[ServiceType, ServiceType]>([
+    ['desktop-service', 'desktop-service'],
+    ['desktop-service', 'runtime-injected'],
+    ['runtime-injected', 'runtime-injected'],
+    ['runtime-injected', 'desktop-service'],
+])('For independent applications of type "%s" and "%s", there is no shared lifecycle', async (type1, type2) => {
+    const app1: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false}, type1);
+    const app2: FakeApplication = await createAppWithConfig(createUuid(), {enabled: false}, type2);
 
     await delay(Duration.STORE_LOADING);
 

--- a/test/utils/fin.ts
+++ b/test/utils/fin.ts
@@ -13,7 +13,7 @@ export function resetFin(): void {
     emitter.removeAllListeners();
 
     const appList = Array.from(apps.values());
-    appList.forEach(app => {
+    appList.forEach((app) => {
         app.removeAllListeners();
 
         if (app.identity.uuid !== 'primaryApp') {

--- a/test/utils/fin.ts
+++ b/test/utils/fin.ts
@@ -9,6 +9,19 @@ import {FakeWindow} from './FakeWindow';
 const emitter = new EventEmitter();
 const apps = new Map<string, FakeApplication>();
 
+export function resetFin(): void {
+    emitter.removeAllListeners();
+
+    const appList = Array.from(apps.values());
+    appList.forEach(app => {
+        app.removeAllListeners();
+
+        if (app.identity.uuid !== 'primaryApp') {
+            apps.delete(app.identity.uuid);
+        }
+    });
+}
+
 interface SystemAppInfo extends AppState, Identity {
     parentUuid: string;
 }


### PR DESCRIPTION
Loader will extract application config from any application that references the service using a `<NAME>Api` flag. In these cases, config is specified by a sibling `<NAME>Config` property.

Loader will also extract "desktop" level config, if the provider contains a `<NAME>Manifest` property in it's application arguments. This is the URL to a manifest with the same UUID (or base UUID, excluding the appended runtime version) as the provider. This is used as an internal-only mechanism for setting "fake" desktop-level config, for use in demo apps and integration testing.